### PR TITLE
Rename SuspendableRequestHandler to ContextWaitingForJob

### DIFF
--- a/src/dlsnode/connection/DlsConnectionHandler.d
+++ b/src/dlsnode/connection/DlsConnectionHandler.d
@@ -411,14 +411,14 @@ public class DlsConnectionHandler
 
         /***********************************************************************
 
-            EventFDSuspendableRequestHandler newer.
+            EventFDContextAwaitingJob newer.
 
         ***********************************************************************/
 
-        override protected EventFDSuspendableRequestHandler
-             new_suspendable_request_handler ( )
+        override protected EventFDContextAwaitingJob
+             new_waiting_context ( )
         {
-            return new EventFDSuspendableRequestHandler(
+            return new EventFDContextAwaitingJob(
                     new FiberSelectEvent(this.outer.fiber));
         }
 
@@ -541,12 +541,12 @@ public class DlsConnectionHandler
 
         /***********************************************************************
 
-            EventFDSuspendableRequestHandler initialiser.
+            EventFDContextAwaitingJob initialiser.
 
         ***********************************************************************/
 
-        override protected void init_suspendable_request_handler (
-                EventFDSuspendableRequestHandler req )
+        override protected void init_waiting_context (
+                EventFDContextAwaitingJob req )
         {
             req.setFiber(this.outer.fiber);
         }

--- a/src/dlsnode/connection/SharedResources.d
+++ b/src/dlsnode/connection/SharedResources.d
@@ -34,7 +34,7 @@ import ocean.transition;
 
 public import ocean.io.select.client.FiberSelectEvent;
 
-public import dlsnode.util.aio.EventFDSuspendableRequestHandler;
+public import dlsnode.util.aio.EventFDContextAwaitingJob;
 
 public import ocean.text.regex.PCRE;
 
@@ -82,7 +82,7 @@ public struct ConnectionResources
     hash_t[] hash_buffer;
     ubyte[] record_buffer;
     FiberSelectEvent event;
-    EventFDSuspendableRequestHandler suspendable_request_handler;
+    EventFDContextAwaitingJob waiting_context;
     LoopCeder loop_ceder;
     StorageEngineStepIterator iterator;
     StorageEngineFileIterator bucket_iterator;

--- a/src/dlsnode/request/PutBatchRequest.d
+++ b/src/dlsnode/request/PutBatchRequest.d
@@ -100,7 +100,7 @@ public scope class PutBatchRequest : Protocol.PutBatch
     final override protected bool putRecord ( cstring channel, cstring key, cstring value )
     {
         this.storage_channel.put(key, value, *this.resources.record_buffer,
-                this.resources.suspendable_request_handler);
+                this.resources.waiting_context);
 
         this.resources.node_info.record_action_counters
             .increment("handled", value.length);

--- a/src/dlsnode/request/PutRequest.d
+++ b/src/dlsnode/request/PutRequest.d
@@ -88,7 +88,7 @@ public scope class PutRequest : Protocol.Put
         auto dls_channel = downcast!(StorageEngine)(storage_channel);
         assert(dls_channel);
         dls_channel.put(key, value, *this.resources.record_buffer,
-                this.resources.suspendable_request_handler);
+                this.resources.waiting_context);
 
         return true;
     }

--- a/src/dlsnode/request/RedistributeRequest.d
+++ b/src/dlsnode/request/RedistributeRequest.d
@@ -291,7 +291,7 @@ scope class RedistributeRequest: Protocol.Redistribute
 
         // Open the bucket for the reading
         scope file = new BucketFile(
-                this.resources.async_io, this.resources.suspendable_request_handler,
+                this.resources.async_io, this.resources.waiting_context,
                 tmp_file_path, this.input_buffer[]);
 
         scope (exit) file.close();
@@ -342,7 +342,7 @@ scope class RedistributeRequest: Protocol.Redistribute
         // Read values from the channel and pack them into the batch
         do
         {
-            eof = file.nextRecord (this.resources.suspendable_request_handler, header);
+            eof = file.nextRecord (this.resources.waiting_context, header);
 
             if (eof)
             {
@@ -350,7 +350,7 @@ scope class RedistributeRequest: Protocol.Redistribute
             }
 
             this.resources.value_buffer().length = header.len;
-            file.readRecordValue (this.resources.suspendable_request_handler,
+            file.readRecordValue (this.resources.waiting_context,
                     header, *this.resources.value_buffer());
             this.resources.key_buffer().length = Hash.HexDigest.length;
             Hash.toHexString(header.key, *this.resources.key_buffer());

--- a/src/dlsnode/request/model/IterationMixin.d
+++ b/src/dlsnode/request/model/IterationMixin.d
@@ -118,12 +118,12 @@ public template ChannelIteration ( alias resources, IterationKind kind,
             assert (iterator);
             static if (kind == IterationKind.Ranged)
             {
-                iterator.getRange(resources.suspendable_request_handler,
+                iterator.getRange(resources.waiting_context,
                         this.key_lower, this.key_upper);
             }
             else
             {
-                iterator.getAll(resources.suspendable_request_handler);
+                iterator.getAll(resources.waiting_context);
             }
         }
 
@@ -154,7 +154,7 @@ public template ChannelIteration ( alias resources, IterationKind kind,
         // loops either until match is found or last key processed
         while (true)
         {
-            this.iterator.next(this.resources.suspendable_request_handler);
+            this.iterator.next(this.resources.waiting_context);
 
             resources.loop_ceder.handleCeding();
 
@@ -162,7 +162,7 @@ public template ChannelIteration ( alias resources, IterationKind kind,
                 return false;
 
             key = iterator.key();
-            value = iterator.value(this.resources.suspendable_request_handler);
+            value = iterator.value(this.resources.waiting_context);
 
             static if (kind == IterationKind.Ranged)
             {

--- a/src/dlsnode/storage/StorageEngine.d
+++ b/src/dlsnode/storage/StorageEngine.d
@@ -26,7 +26,7 @@ import swarm.node.storage.model.IStorageEngine;
 
 import ocean.util.log.Logger;
 
-import dlsnode.util.aio.SuspendableRequestHandler;
+import dlsnode.util.aio.ContextAwaitingJob;
 import dlsnode.util.aio.AsyncIO;
 
 import ocean.transition;
@@ -165,7 +165,7 @@ public class StorageEngine : IStorageEngine
         ***********************************************************************/
 
         public void put ( hash_t key, cstring value, ref ubyte[] record_buffer,
-                SuspendableRequestHandler suspendable_request_handler )
+                ContextAwaitingJob waiting_context )
         {
             // Calculate file hash.
             SlotBucket sb;
@@ -206,7 +206,7 @@ public class StorageEngine : IStorageEngine
                 file.setDir(this.outer.id, this.outer.channel_dir);
             }
 
-            file.put(key, value, record_buffer, suspendable_request_handler);
+            file.put(key, value, record_buffer, waiting_context);
         }
 
 
@@ -330,7 +330,7 @@ public class StorageEngine : IStorageEngine
             value = record value
             record_buffer = buffer used internally for rendering entire record
                             passing it to BufferedOutput.
-            suspendable_request_handler = suspendable_request_handler to block
+            waiting_context = waiting_context to block
                 and wait on for IO to happen
 
         Returns:
@@ -339,10 +339,10 @@ public class StorageEngine : IStorageEngine
     ***********************************************************************/
 
     typeof(this) put ( cstring key, cstring value, ref ubyte[] record_buffer,
-            SuspendableRequestHandler suspendable_request_handler )
+            ContextAwaitingJob waiting_context )
     {
         this.writers.put(Hash.straightToHash(key), value, record_buffer,
-                suspendable_request_handler);
+                waiting_context);
 
         return this;
     }
@@ -354,15 +354,15 @@ public class StorageEngine : IStorageEngine
 
         Params:
             iterator = iterator to initialise
-            suspendable_request_handler = SuspendableRequestHandler instance to
+            waiting_context = ContextAwaitingJob instance to
                 block the caller on.
 
     ***********************************************************************/
 
     public typeof(this) getAll ( IStorageEngineStepIterator iterator,
-            SuspendableRequestHandler suspendable_request_handler )
+            ContextAwaitingJob waiting_context )
     {
-        (cast(IStorageEngineStepIterator)iterator).getAll(suspendable_request_handler);
+        (cast(IStorageEngineStepIterator)iterator).getAll(waiting_context);
 
         return this;
     }
@@ -377,15 +377,15 @@ public class StorageEngine : IStorageEngine
             iterator = iterator to initialise
             min = minimum hash to iterate over
             max = maximum hash to iterate over
-            suspendable_request_handler = SuspendableRequestHandler instance to
+            waiting_context = ContextAwaitingJob instance to
                 block the caller on.
 
     ***********************************************************************/
 
     public typeof(this) getRange ( IStorageEngineStepIterator iterator,
-            cstring min, cstring max, SuspendableRequestHandler suspendable_request_handler )
+            cstring min, cstring max, ContextAwaitingJob waiting_context )
     {
-        (cast(IStorageEngineStepIterator)iterator).getRange(suspendable_request_handler, min, max);
+        (cast(IStorageEngineStepIterator)iterator).getRange(waiting_context, min, max);
 
         return this;
     }

--- a/src/dlsnode/storage/iterator/model/IStorageEngineStepIterator.d
+++ b/src/dlsnode/storage/iterator/model/IStorageEngineStepIterator.d
@@ -24,7 +24,7 @@
 *******************************************************************************/
 
 module dlsnode.storage.iterator.model.IStorageEngineStepIterator;
-import dlsnode.util.aio.SuspendableRequestHandler;
+import dlsnode.util.aio.ContextAwaitingJob;
 
 import ocean.transition;
 
@@ -37,11 +37,11 @@ interface IStorageEngineStepIterator
         with the methods below.
 
         Params:
-            suspendable_request_handler = SuspendableRequestHandler instance to block the caller on.
+            waiting_context = ContextAwaitingJob instance to block the caller on.
 
     ***************************************************************************/
 
-    public void getAll ( SuspendableRequestHandler suspendable_request_handler );
+    public void getAll ( ContextAwaitingJob waiting_context );
 
 
     /***************************************************************************
@@ -52,7 +52,7 @@ interface IStorageEngineStepIterator
         the methods below.
 
         Params:
-            suspendable_request_handler = SuspendableRequestHandler instance to block the caller on.
+            waiting_context = ContextAwaitingJob instance to block the caller on.
             min = string containing the hexadecimal key of the first
                 record to iterate
             max = string containing the hexadecimal key of the last
@@ -60,7 +60,7 @@ interface IStorageEngineStepIterator
 
     ***************************************************************************/
 
-    public void getRange ( SuspendableRequestHandler suspendable_request_handler, cstring min, cstring max );
+    public void getRange ( ContextAwaitingJob waiting_context, cstring min, cstring max );
 
 
     /***************************************************************************
@@ -81,14 +81,14 @@ interface IStorageEngineStepIterator
         to.
 
         Params:
-            event = SuspendableRequestHandler to block the fiber on until read is completed
+            event = ContextAwaitingJob to block the fiber on until read is completed
 
         Returns:
             current value
 
     ***************************************************************************/
 
-    public cstring value ( SuspendableRequestHandler suspendable_request_handler );
+    public cstring value ( ContextAwaitingJob waiting_context );
 
 
     /***************************************************************************
@@ -97,11 +97,11 @@ interface IStorageEngineStepIterator
         the storage engine, if this.started is false.
 
         Params:
-            event = SuspendableRequestHandler to block the fiber on until read is completed
+            event = ContextAwaitingJob to block the fiber on until read is completed
 
     ***************************************************************************/
 
-    public void next ( SuspendableRequestHandler suspendable_request_handler );
+    public void next ( ContextAwaitingJob waiting_context );
 
 
     /***************************************************************************

--- a/src/dlsnode/storage/protocol/StorageProtocolV1.d
+++ b/src/dlsnode/storage/protocol/StorageProtocolV1.d
@@ -53,7 +53,7 @@ scope class StorageProtocolV1: IStorageProtocol
         Reads next record header from the file, if any.
 
         Params:
-            suspendable_request_handler = SuspendableRequestHandler to block
+            waiting_context = ContextAwaitingJob to block
                 the fiber on until read is completed
             file = bucket file instance to read from
             header = record header to fill
@@ -64,7 +64,7 @@ scope class StorageProtocolV1: IStorageProtocol
     **************************************************************************/
 
     public override bool nextRecord (
-            SuspendableRequestHandler suspendable_request_handler,
+            ContextAwaitingJob waiting_context,
             BucketFile file, ref RecordHeader header )
     {
         RecordHeaderV1 header_buf;
@@ -75,7 +75,7 @@ scope class StorageProtocolV1: IStorageProtocol
         }
 
         // Read header of next record
-        file.readData(suspendable_request_handler,
+        file.readData(waiting_context,
                 (cast(void*)&header_buf)[0..header_buf.sizeof]);
 
         // check the record header
@@ -110,7 +110,7 @@ scope class StorageProtocolV1: IStorageProtocol
         Reads the next record value from the file.
 
         Params:
-            suspendable_request_handler = SuspendableRequestHandler to block
+            waiting_context = ContextAwaitingJob to block
                 the fiber on until read is completed
             file = bucket file instance to read from
             header = current record's header
@@ -119,12 +119,12 @@ scope class StorageProtocolV1: IStorageProtocol
     **************************************************************************/
 
     public override void readRecordValue (
-            SuspendableRequestHandler suspendable_request_handler,
+            ContextAwaitingJob waiting_context,
             BucketFile file, RecordHeader header, ref mstring value )
     {
         // Read value from file
         value.length = header.len;
-        file.readData(suspendable_request_handler, value);
+        file.readData(waiting_context, value);
     }
 
     /**************************************************************************
@@ -132,7 +132,7 @@ scope class StorageProtocolV1: IStorageProtocol
         Skips the next record value in the file.
 
         Params:
-            suspendable_request_handler = SuspendableRequestHandler to block
+            waiting_context = ContextAwaitingJob to block
                 the fiber on until read is completed
             file = bucket file instance to read from
             header = current record's header
@@ -140,7 +140,7 @@ scope class StorageProtocolV1: IStorageProtocol
     **************************************************************************/
 
     public override void skipRecordValue (
-            SuspendableRequestHandler suspendable_request_handler,
+            ContextAwaitingJob waiting_context,
             BucketFile file, ref RecordHeader header )
     {
         file.seek(header.len, File.Anchor.Current);

--- a/src/dlsnode/storage/protocol/model/IStorageProtocol.d
+++ b/src/dlsnode/storage/protocol/model/IStorageProtocol.d
@@ -19,7 +19,7 @@ public import dlsnode.storage.Record;
 public import dlsnode.storage.BucketFile;
 public import ocean.io.stream.Buffered;
 
-public import dlsnode.util.aio.SuspendableRequestHandler;
+public import dlsnode.util.aio.ContextAwaitingJob;
 
 interface IStorageProtocol
 {
@@ -28,7 +28,7 @@ interface IStorageProtocol
         Reads next record header from the file, if any.
 
         Params:
-            suspendable_request_handler = SuspendableRequestHandler to block
+            waiting_context = ContextAwaitingJob to block
                 the fiber on until read is completed
             file = bucket file instance to read from
             header = record header to fill
@@ -39,7 +39,7 @@ interface IStorageProtocol
     **************************************************************************/
 
     public bool nextRecord (
-            SuspendableRequestHandler suspendable_request_handler,
+            ContextAwaitingJob waiting_context,
             BucketFile file, ref RecordHeader header );
 
 
@@ -48,7 +48,7 @@ interface IStorageProtocol
         Reads the next record value from the file.
 
         Params:
-            suspendable_request_handler = SuspendableRequestHandler to block
+            waiting_context = ContextAwaitingJob to block
                 the fiber on until read is completed
             file = bucket file instance to read from
             header = current record's header
@@ -57,7 +57,7 @@ interface IStorageProtocol
     **************************************************************************/
 
     public void readRecordValue (
-            SuspendableRequestHandler suspendable_request_handler,
+            ContextAwaitingJob waiting_context,
             BucketFile file, RecordHeader header, ref mstring value);
 
 
@@ -66,7 +66,7 @@ interface IStorageProtocol
         Skips the next record value in the file.
 
         Params:
-            suspendable_request_handler = SuspendableRequestHandler to block
+            waiting_context = ContextAwaitingJob to block
                 the fiber on until read is completed
             file = bucket file instance to read from
             header = current record's header
@@ -74,7 +74,7 @@ interface IStorageProtocol
     **************************************************************************/
 
     public void skipRecordValue (
-            SuspendableRequestHandler suspendable_request_handler,
+            ContextAwaitingJob waiting_context,
             BucketFile file, ref RecordHeader header );
 
 

--- a/src/dlsnode/storage/util/RecentFiles.d
+++ b/src/dlsnode/storage/util/RecentFiles.d
@@ -13,7 +13,7 @@
 
 module dlsnode.storage.util.RecentFiles;
 
-import dlsnode.util.aio.SuspendableRequestHandler;
+import dlsnode.util.aio.ContextAwaitingJob;
 import ocean.util.container.cache.LRUCache;
 
 import dlsnode.storage.BufferedBucketOutput;
@@ -39,8 +39,8 @@ class RecentFiles: LRUCache!(BufferedBucketOutput)
 
         Acquires an existing bucket from cache, or creates a new one, and drops
         an old one. Because on dropping old one sync might be required, the
-        SuspendableRequestHandler of the current request needs to be passed, which
-        is the reason why this method accepts suspendable_request_handler - it merely passes it
+        ContextAwaitingJob of the current request needs to be passed, which
+        is the reason why this method accepts waiting_context - it merely passes it
         to `itemDropped` (indirecly, since that method is called by the base
         class).
 

--- a/src/dlsnode/util/aio/ContextAwaitingJob.d
+++ b/src/dlsnode/util/aio/ContextAwaitingJob.d
@@ -1,6 +1,6 @@
 /*******************************************************************************
 
-    Common interface for various types of suspendable requests waiting for
+    Common interface for various types of suspendable contexts waiting for
     AsyncIO to finish.
 
     copyright:
@@ -11,10 +11,10 @@
 
 *******************************************************************************/
 
-module dlsnode.util.aio.SuspendableRequestHandler;
+module dlsnode.util.aio.ContextAwaitingJob;
 
 /// Ditto
-abstract class SuspendableRequestHandler
+abstract class ContextAwaitingJob
 {
     import ocean.core.array.Mutation: copy;
     import dlsnode.util.aio.internal.JobQueue: Job;
@@ -30,7 +30,7 @@ abstract class SuspendableRequestHandler
 
     /***************************************************************************
 
-        Pointer to the AIO job suspended on this SuspendableRequestHandler.
+        Pointer to the AIO job suspended on this ContextAwaitingJob.
         Used for canceling the jobs. TODO: is the closure possible combining
         remove_dg and job?
 
@@ -40,7 +40,7 @@ abstract class SuspendableRequestHandler
 
     /***************************************************************************
 
-        Yields the control to the suspendable request, indicating that the aio
+        Yields the control to the suspendable context, indicating that the aio
         operation has been done.
 
     ***************************************************************************/
@@ -49,7 +49,7 @@ abstract class SuspendableRequestHandler
 
     /***************************************************************************
 
-        Cedes the control from the suspendable request, waiting for the aio
+        Cedes the control from the suspendable context, waiting for the aio
         operation to be done. Implementation is defined by the concrete classes.
 
     ***************************************************************************/
@@ -58,7 +58,7 @@ abstract class SuspendableRequestHandler
 
     /***************************************************************************
 
-        Cedes the control from the suspendable request, waiting for the aio
+        Cedes the control from the suspendable context, waiting for the aio
         operation to be done. Called by AsyncIO framework internally.
 
         Params:
@@ -76,7 +76,7 @@ abstract class SuspendableRequestHandler
 
     /***************************************************************************
 
-        Yields the control to the suspendable request, indicating that the aio
+        Yields the control to the suspendable context, indicating that the aio
         operation has been done. Called by the AsyncIO framework internally.
 
     ***************************************************************************/

--- a/src/dlsnode/util/aio/EventFDContextAwaitingJob.d
+++ b/src/dlsnode/util/aio/EventFDContextAwaitingJob.d
@@ -1,6 +1,6 @@
 /*******************************************************************************
 
-    FiberSelectEvent suspend/resume interface for suspendable requests waiting
+    FiberSelectEvent suspend/resume interface for suspendable contexts waiting
     for AsyncIO to finish.
 
     copyright:
@@ -11,14 +11,14 @@
 
 *******************************************************************************/
 
-module dlsnode.util.aio.EventFDSuspendableRequestHandler;
+module dlsnode.util.aio.EventFDContextAwaitingJob;
 
 import ocean.io.select.client.FiberSelectEvent;
 import ocean.io.select.fiber.SelectFiber;
-import dlsnode.util.aio.SuspendableRequestHandler;
+import dlsnode.util.aio.ContextAwaitingJob;
 
 /// ditto
-class EventFDSuspendableRequestHandler: SuspendableRequestHandler
+class EventFDContextAwaitingJob: ContextAwaitingJob
 {
     /***************************************************************************
 
@@ -50,7 +50,7 @@ class EventFDSuspendableRequestHandler: SuspendableRequestHandler
 
     /***************************************************************************
 
-        Yields the control to the suspendable request, indicating that the aio
+        Yields the control to the suspendable context, indicating that the aio
         operation has been done.
 
     ***************************************************************************/
@@ -62,7 +62,7 @@ class EventFDSuspendableRequestHandler: SuspendableRequestHandler
 
     /***************************************************************************
 
-        Cedes the control from the suspendable request, waiting for the aio
+        Cedes the control from the suspendable context, waiting for the aio
         operation to be done.
 
     ***************************************************************************/

--- a/src/dlsnode/util/aio/internal/AioScheduler.d
+++ b/src/dlsnode/util/aio/internal/AioScheduler.d
@@ -11,7 +11,7 @@
     themselves while accessing the queue.
 
     At the beginning, both queues are empty. When worker thread is finished
-    processing the request, SuspendableRequestHandler is put into the workers'
+    processing the request, ContextAwaitingJob is put into the workers'
     queue and notifies the main thread that there are request that it needs to
     wake up. However, since the main thread may not immediately do this, more
     than one request could end up in the queue. Once main thread is ready to
@@ -41,7 +41,7 @@ class AioScheduler: ISelectEvent
 {
     import ocean.sys.ErrnoException;
     import core.sys.posix.pthread;
-    import dlsnode.util.aio.SuspendableRequestHandler;
+    import dlsnode.util.aio.ContextAwaitingJob;
     import dlsnode.util.aio.internal.MutexOps;
     import swarm.neo.util.TreeQueue;
     import dlsnode.util.aio.internal.JobQueue: Job;
@@ -150,7 +150,7 @@ class AioScheduler: ISelectEvent
         Discards the results of the given AIO operation.
 
         Params:
-            req = SuspendableRequestHandler instance that was waiting for results
+            req = ContextAwaitingJob instance that was waiting for results
 
     ***************************************************************************/
 
@@ -194,7 +194,7 @@ class AioScheduler: ISelectEvent
 
         foreach (job; *this.waking_queue)
         {
-            auto req = job.suspendable_request_handler;
+            auto req = job.waiting_context;
             assert (req);
 
             job.finished();

--- a/src/dlsnode/util/aio/internal/JobQueue.d
+++ b/src/dlsnode/util/aio/internal/JobQueue.d
@@ -21,7 +21,7 @@ import core.sys.posix.pthread;
 import ocean.sys.ErrnoException;
 
 import dlsnode.util.aio.AsyncIO;
-import dlsnode.util.aio.SuspendableRequestHandler;
+import dlsnode.util.aio.ContextAwaitingJob;
 import dlsnode.util.aio.internal.AioScheduler;
 
 /**********************************************************************
@@ -93,11 +93,11 @@ public static struct Job
 
     /****************************************************************
 
-        SuspendableRequestHandler used to wake the job.
+        ContextAwaitingJob used to wake the job.
 
     ****************************************************************/
 
-    public SuspendableRequestHandler suspendable_request_handler;
+    public ContextAwaitingJob waiting_context;
 
     /****************************************************************
 


### PR DESCRIPTION
This renames all instances of *SuspendableRequestHandler to
ContextWaitingForJob, since the AsyncIO framework doesn't necessarily
need to a) suspend the caller b) to have anything to do with the
requests.