### PR TITLE
Specify the name for the versioning test to prevent sandbox clashes

### DIFF
--- a/test/versioning/main.d
+++ b/test/versioning/main.d
@@ -113,6 +113,6 @@ private class DlsVersioningRunner : TurtleRunnerTask!(TestedAppKind.Daemon)
 int main ( istring[] args )
 {
     auto runner = new TurtleRunner!(DlsVersioningRunner)("dlsnode",
-            "test.versioning.cases");
+            "test.versioning.cases", "versioning_test");
     return runner.main(args);
 }


### PR DESCRIPTION
If main tests and versioning tests are running in parallel, they will
test the same binary name, having the same sandbox directory, hence
clashing.