### PR TITLE
Update to GetRange_v1 protocol

### DIFF
--- a/src/dlsnode/connection/neo/SharedResources.d
+++ b/src/dlsnode/connection/neo/SharedResources.d
@@ -87,6 +87,14 @@ public final class SharedResources
 
     /***************************************************************************
 
+        Lzo object for compressing the record batches.
+
+    ***************************************************************************/
+
+    private Lzo lzo;
+
+    /***************************************************************************
+
         Pool of CompiledRegex instances to use.
 
     ***************************************************************************/
@@ -134,6 +142,7 @@ public final class SharedResources
             size_t file_buffer_size )
     {
         this.pcre = new PCRE;
+        this.lzo = new Lzo;
         this.file_buffer_size = file_buffer_size;
         this.async_io = async_io;
         this.storage_channels = storage_channels;
@@ -259,6 +268,18 @@ public final class SharedResources
             return this.acquired_void_buffers.acquire();
         }
 
+
+        /***********************************************************************
+
+            Returns:
+                lzo object for compressing the record batches.
+
+        ***********************************************************************/
+
+        override public Lzo getLzo ( )
+        {
+            return this.outer.lzo;
+        }
 
         /***********************************************************************
 

--- a/src/dlsnode/neo/request/GetRange.d
+++ b/src/dlsnode/neo/request/GetRange.d
@@ -63,9 +63,9 @@ public void handle ( Object shared_resources, RequestOnConn connection,
 
     switch (cmdver)
     {
-        case 0:
+        case 1:
             scope rq_resources = dls_shared_resources.new RequestResources;
-            scope rq = new GetRangeImpl_v0(dls_shared_resources.storage_channels, rq_resources);
+            scope rq = new GetRangeImpl_v1(dls_shared_resources.storage_channels, rq_resources);
             rq.handle(connection, msg_payload);
             break;
 
@@ -83,11 +83,11 @@ public void handle ( Object shared_resources, RequestOnConn connection,
 
 /*******************************************************************************
 
-    Node implementation of the GetRangeProtocol_v0.
+    Node implementation of the GetRangeProtocol_v1.
 
 *******************************************************************************/
 
-private scope class GetRangeImpl_v0: GetRangeProtocol_v0
+private scope class GetRangeImpl_v1: GetRangeProtocol_v1
 {
     import swarm.util.Hash;
     import dlsnode.storage.StorageChannels;
@@ -428,18 +428,6 @@ private scope class GetRangeImpl_v0: GetRangeProtocol_v0
     ***************************************************************************/
 
     override protected void requestFinished ()
-    {
-        this.job_notification.discardResults();
-    }
-
-    /***************************************************************************
-
-        Indicates storage engine that this request has been suspended and that
-        results are no longer required.
-
-    ***************************************************************************/
-
-    override protected void requestSuspended ()
     {
         this.job_notification.discardResults();
     }


### PR DESCRIPTION
* submodules/dlsproto neo-alpha-1(0e6da84)...neo-alpha-1+5(4f905e1) (5 commits)
  > Repeat the iteration step when resumed from the storage engine
  > Don't resume the Task on node_error in Blocking task support
  > Migrate GetRange to multi-fiber-framework
  > Fix documentation for dlstest.DlsClient.connectionNotifier
  > Update submodules to latest versions