### PR TITLE
Reload systemd daemon before enabling the service

### DIFF
--- a/pkg/after_install.sh
+++ b/pkg/after_install.sh
@@ -25,6 +25,6 @@ then
 fi
 
 if [ -d /run/systemd/system ]; then
-    systemctl enable dlsnode
     systemctl daemon-reload
+    systemctl enable dlsnode
 fi


### PR DESCRIPTION
To enable the service, the systemd needs know the service first, so the
daemon reload is now done before enable.