### PR TITLE
Replace `size` with `maxsize` in the logrotate configs

### DIFF
--- a/deploy/logrotate/dlsnode-logs
+++ b/deploy/logrotate/dlsnode-logs
@@ -16,7 +16,7 @@
 	notifempty
 	delaycompress
 	compress
-	size 500M
+	maxsize 500M
 	sharedscripts
 	postrotate
 		service dls reload >/dev/null 2>&1


### PR DESCRIPTION
`size` criteria doesn't work with the time criteria (i.e. weekly),
so we're going to move the `maxsize` which can be used with it:

```
maxsize *size*

Log  files  are  rotated  when  they  grow bigger than
size bytes even before  the  additionally  specified  time  interval
(daily,  weekly, monthly,  or  yearly).  The related size option is
similar except that it is mutually exclusive with the time interval
options, and it causes log  files  to  be  rotated without regard for
the last rotation time.  When maxsize is used, both the size and
timestamp of a  log  file  are considered.
```