### PR TITLE
Report system stats from the DLS node

### DIFF
--- a/src/dlsnode/main.d
+++ b/src/dlsnode/main.d
@@ -360,6 +360,7 @@ public class DlsNodeServer : DaemonApp
 
     override protected void onStatsTimer ( )
     {
+        this.reportSystemStats();
         this.dls_stats.log();
         this.stats_ext.stats_log.add(ocean.util.log.Logger.Log.stats());
         this.stats_ext.stats_log.add(getNumFilesStats());


### PR DESCRIPTION
Only file descriptors stats were reported, but not the CPU/memory stats.