### PR TITLE
Adapt logrotate for the systemd changes

### DIFF
--- a/deploy/logrotate/dlsnode-logs
+++ b/deploy/logrotate/dlsnode-logs
@@ -19,6 +19,10 @@
 	maxsize 500M
 	sharedscripts
 	postrotate
-		service dls reload >/dev/null 2>&1
+        if [ -d /run/systemd/system ]; then
+            systemctl reload dlsnode >/dev/null 2>&1
+        else
+            service dls reload >/dev/null 2>&1
+        fi
 	endscript
 }


### PR DESCRIPTION
The service in the systemd deployment is called "dlsnode" and not "dls"
anymore. This adapts the logrotate config is adapted for this change.