### PR TITLE
Change the name in logrotate file to match the systemd service

### DIFF
--- a/deploy/logrotate/dlsnode-logs
+++ b/deploy/logrotate/dlsnode-logs
@@ -19,6 +19,6 @@
 	maxsize 500M
 	sharedscripts
 	postrotate
-		service dls reload >/dev/null 2>&1
+		service dlsnode reload >/dev/null 2>&1
 	endscript
 }


### PR DESCRIPTION
This adapts logrotate file to reload the proper service name.