### PR TITLE
Use `systemctl reload` to reload config files

### DIFF
--- a/deploy/logrotate/dlsnode-logs
+++ b/deploy/logrotate/dlsnode-logs
@@ -19,6 +19,6 @@
 	maxsize 500M
 	sharedscripts
 	postrotate
-		service dls reload >/dev/null 2>&1
+		systemctl reload dlsnode
 	endscript
 }


### PR DESCRIPTION
Instead of relying on the fixed binary name, which has problems
when overriding systemd services, this relies on service name
which is fixed.