### PR TITLE
Resolve static constructor circle, fix deprecations for upstream v2.078

### DIFF
--- a/Build.mak
+++ b/Build.mak
@@ -1,9 +1,7 @@
 override DFLAGS += -w
 override LDFLAGS += -llzo2 -lebtree -lrt -lgcrypt -lgpg-error -lglib-2.0
 
-ifneq ($(DVER),1)
-	DC := dmd-transitional
-else
+ifeq ($(DVER),1)
 override DFLAGS += -v2 -v2=-static-arr-params
 endif
 

--- a/src/dlsnode/connection/DlsConnectionHandler.d
+++ b/src/dlsnode/connection/DlsConnectionHandler.d
@@ -489,7 +489,7 @@ public class DlsConnectionHandler
 
         override protected RecordBatch new_decompress_record_batch ( )
         {
-            return new RecordBatch(this.setup.lzo.lzo, DlsConst.PutBatchSize);
+            return new RecordBatch(this.setup.lzo.lzo);
         }
 
         /***********************************************************************

--- a/src/dlsnode/main.d
+++ b/src/dlsnode/main.d
@@ -144,7 +144,7 @@ public class DlsNodeServer : DaemonApp
     import dlsproto.client.legacy.DlsConst;
     import swarm.util.node.log.Stats;
 
-    import ocean.core.ExceptionDefinitions : IOException, OutOfMemoryException;
+    import ocean.core.ExceptionDefinitions : IOException;
     import ocean.sys.ErrnoException;
 
     import core.sys.posix.signal;
@@ -469,7 +469,7 @@ public class DlsNodeServer : DaemonApp
             // thrown by ocean's regular IO methods. This is not something
             // that normally occurs, and we need to log it.
             logger.error("File.IOException caught in eventLoop: '{}' @ {}:{}",
-                getMsg(e), e.file, e.line);
+                e.message(), e.file, e.line);
         }
         else if ( cast(MessageFiber.KilledException)exception ||
              cast(IOWarning)exception ||
@@ -482,7 +482,7 @@ public class DlsNodeServer : DaemonApp
         else
         {
             logger.error("Exception caught in eventLoop: '{}' @ {}:{} on {}:{}",
-                getMsg(exception), exception.file, exception.line,
+                exception.message(), exception.file, exception.line,
                 this.server_config.address(), this.server_config.port());
         }
     }
@@ -618,7 +618,7 @@ public class DlsNodeServer : DaemonApp
         catch (Exception e)
         {
             logger.fatal("FAILED to terminate app: {}@{}:{}",
-                    getMsg(e), e.file, e.line);
+                    e.message(), e.file, e.line);
             throw e;
         }
 

--- a/src/dlsnode/neo/request/GetRange.d
+++ b/src/dlsnode/neo/request/GetRange.d
@@ -231,7 +231,7 @@ scope class GetRangeImpl_v2: GetRangeProtocol_v2
                 }
                 catch ( .PCRE.PcreException e )
                 {
-                    .log.error("Exception during PCRE match with `{}` on channel '{}' and "
+                    .log.error("Exception during PCRE match with `{}` on channel '{}' and " ~
                         "key '{}': {} (error code: {}) @ {}:{} (aborting iteration)",
                         this.filter_string, this.dls_channel.id, key,
                         e.msg, e.error, e.file, e.line);
@@ -239,7 +239,7 @@ scope class GetRangeImpl_v2: GetRangeProtocol_v2
                 }
                 catch ( Exception e )
                 {
-                    .log.error("Exception during PCRE match with `{}` on channel '{}' and "
+                    .log.error("Exception during PCRE match with `{}` on channel '{}' and " ~
                         "key '{}': {} @ {}:{} (aborting iteration)",
                         this.filter_string, this.dls_channel.id,
                         key, e.msg, e.file, e.line);
@@ -339,7 +339,7 @@ scope class GetRangeImpl_v2: GetRangeProtocol_v2
                 }
                 catch ( .PCRE.PcreException e )
                 {
-                    .log.error("Exception during PCRE compile of `{}` on channel '{}': "
+                    .log.error("Exception during PCRE compile of `{}` on channel '{}': " ~
                         "{} (error code: {}) @ {}:{} (aborting iteration)",
                         filter, this.dls_channel.id,
                         e.toString(), e.error, e.file, e.line);
@@ -347,7 +347,7 @@ scope class GetRangeImpl_v2: GetRangeProtocol_v2
                 }
                 catch ( Exception e )
                 {
-                    .log.error("Exception during PCRE compile of `{}` on channel '{}': "
+                    .log.error("Exception during PCRE compile of `{}` on channel '{}': " ~
                         "{} @ {}:{} (aborting iteration)",
                         filter, this.dls_channel.id,
                         e.toString(), e.file, e.line);

--- a/src/dlsnode/node/DlsNode.d
+++ b/src/dlsnode/node/DlsNode.d
@@ -124,7 +124,6 @@ public class DlsNode :
         Options neo_options;
         neo_options.requests = requests;
         neo_options.epoll = epoll;
-        neo_options.no_delay = no_delay;
         neo_options.shared_resources =
             new NeoSharedResources.SharedResources(channels,
                 async_io, file_buffer_size);

--- a/src/dlsnode/request/GetRangeRegexRequest.d
+++ b/src/dlsnode/request/GetRangeRegexRequest.d
@@ -89,7 +89,7 @@ scope class GetRangeRegexRequest : Protocol.GetRangeRegex
                 }
                 catch ( .PCRE.PcreException e )
                 {
-                    .log.error("Exception during PCRE match with `{}` on channel '{}' and "
+                    .log.error("Exception during PCRE match with `{}` on channel '{}' and " ~
                         "key '{}': {} (error code: {}) @ {}:{} (aborting iteration)",
                         *this.pcre_filter, *this.resources.channel_buffer, key,
                         e.msg, e.error, e.file, e.line);
@@ -99,7 +99,7 @@ scope class GetRangeRegexRequest : Protocol.GetRangeRegex
                 }
                 catch ( Exception e )
                 {
-                    .log.error("Exception during PCRE match with `{}` on channel '{}' and "
+                    .log.error("Exception during PCRE match with `{}` on channel '{}' and " ~
                         "key '{}': {} @ {}:{} (aborting iteration)",
                         *this.pcre_filter, *this.resources.channel_buffer,
                         key, e.msg, e.file, e.line);
@@ -154,7 +154,7 @@ scope class GetRangeRegexRequest : Protocol.GetRangeRegex
                 }
                 catch ( .PCRE.PcreException e )
                 {
-                    .log.warn("Exception during PCRE compile of `{}` on channel '{}': "
+                    .log.warn("Exception during PCRE compile of `{}` on channel '{}': " ~
                         "{} (error code: {}) @ {}:{} (aborting iteration)",
                         *this.pcre_filter, *this.resources.channel_buffer,
                         e.msg, e.error, e.file, e.line);
@@ -162,7 +162,7 @@ scope class GetRangeRegexRequest : Protocol.GetRangeRegex
                 }
                 catch ( Exception e )
                 {
-                    .log.warn("Exception during PCRE compile of `{}` on channel '{}': "
+                    .log.warn("Exception during PCRE compile of `{}` on channel '{}': " ~
                         "{} @ {}:{} (aborting iteration)",
                         *this.pcre_filter, *this.resources.channel_buffer,
                         e.msg, e.file, e.line);

--- a/src/dlsnode/request/PutRequest.d
+++ b/src/dlsnode/request/PutRequest.d
@@ -59,7 +59,7 @@ public scope class PutRequest : Protocol.Put
     final override protected bool isSizeAllowed ( size_t size )
     {
         // Don't allow records larger than batch size
-        return size <= RecordBatch.DefaultMaxBatchSize;
+        return size <= RecordBatcher.DefaultMaxBatchSize;
     }
 
     /***************************************************************************

--- a/src/dlsnode/request/RedistributeRequest.d
+++ b/src/dlsnode/request/RedistributeRequest.d
@@ -162,12 +162,12 @@ scope class RedistributeRequest: Protocol.Redistribute
             }
             catch ( Exception e )
             {
-                .log.error("Exception thrown while redistributing channel '{}': "
+                .log.error("Exception thrown while redistributing channel '{}': " ~
                         "'{}' @ {}:{}", channel.id, e.msg, e.file, e.line);
             }
         }
 
-        .log.info("Redistribution has been completed. "
+        .log.info("Redistribution has been completed. " ~
                   "Transfered {} records with {} bytes",
                   this.records_redistributed, this.bytes_redistributed);
     }
@@ -223,7 +223,7 @@ scope class RedistributeRequest: Protocol.Redistribute
 
             if ( buckets_iterated % 1_000 == 0 )
             {
-                .log.trace("Progress redistributing channel '{}':  "
+                .log.trace("Progress redistributing channel '{}':  " ~
                            "{} buckets iterated, {} forwarded",
                            channel.id, buckets_iterated, buckets_sent);
             }
@@ -232,7 +232,7 @@ scope class RedistributeRequest: Protocol.Redistribute
             this.resources.loop_ceder.handleCeding();
         }
 
-        .log.trace("Finished redistributing channel '{}':  "
+        .log.trace("Finished redistributing channel '{}':  " ~
                    "{} buckets iterated, {} forwarded",
                    channel.id, buckets_iterated, buckets_sent);
 

--- a/src/dlsnode/storage/StorageEngine.d
+++ b/src/dlsnode/storage/StorageEngine.d
@@ -29,6 +29,7 @@ import ocean.util.log.Logger;
 import dlsnode.util.aio.JobNotification;
 import dlsnode.util.aio.AsyncIO;
 import core.stdc.time;
+import Hash = swarm.util.Hash;
 
 import ocean.transition;
 

--- a/src/dlsnode/storage/checkpoint/CheckpointFile.d
+++ b/src/dlsnode/storage/checkpoint/CheckpointFile.d
@@ -359,7 +359,7 @@ class CheckpointFile
                         }
                         catch (Exception e)
                         {
-                            .log.error("Couldn't process checkpoint entry: {}", getMsg(e));
+                            .log.error("Couldn't process checkpoint entry: {}", e.message());
                         }
 
                     }
@@ -370,7 +370,7 @@ class CheckpointFile
         }
         catch (Exception e)
         {
-            .log.error("Couldn't process checkpoint file: {}", getMsg(e));
+            .log.error("Couldn't process checkpoint file: {}", e.message());
             return false;
         }
     }

--- a/src/dlsnode/storage/checkpoint/CheckpointService.d
+++ b/src/dlsnode/storage/checkpoint/CheckpointService.d
@@ -691,7 +691,7 @@ class CheckpointService
             }
             catch (Exception e)
             {
-                .log.error("Exception in checkkpoint_delegate: {}", getMsg(e));
+                .log.error("Exception in checkkpoint_delegate: {}", e.message());
             }
         }
     }

--- a/src/dlsnode/storage/checkpoint/CheckpointService.d
+++ b/src/dlsnode/storage/checkpoint/CheckpointService.d
@@ -70,7 +70,7 @@ static this ( )
 class CheckpointService
 {
     import dlsnode.storage.checkpoint.CheckpointFile;
-    import ocean.io.Path;
+    import OceanPath = ocean.io.Path;
     import ocean.io.device.File;
     import ocean.io.FilePath;
     import ocean.io.select.fiber.SelectFiber;
@@ -506,7 +506,7 @@ class CheckpointService
 
         if (file_path.exists)
         {
-            FS.remove(file_path.cString);
+            OceanPath.remove(file_path.cString);
         }
     }
 
@@ -571,7 +571,7 @@ class CheckpointService
             // Remove the tmp file
             if (this.tmp_file_path.exists)
             {
-                FS.remove(this.tmp_file_path.cString);
+                OceanPath.remove(this.tmp_file_path.cString);
             }
         }
 
@@ -589,7 +589,7 @@ class CheckpointService
             {
                 if (this.tmp_file_path.exists)
                 {
-                    FS.remove(this.tmp_file_path.cString);
+                    OceanPath.remove(this.tmp_file_path.cString);
                 }
             }
         }
@@ -705,7 +705,7 @@ class CheckpointService
 
     private void renameCheckpointFile ( )
     {
-        FS.rename(tmp_file_path.cString, file_path.cString);
+        rename(tmp_file_path.cString.ptr, file_path.cString.ptr);
     }
 }
 

--- a/src/dlsnode/storage/protocol/StorageProtocolLegacy.d
+++ b/src/dlsnode/storage/protocol/StorageProtocolLegacy.d
@@ -17,22 +17,9 @@ import ocean.transition;
 import dlsnode.storage.protocol.model.IStorageProtocol;
 import dlsnode.storage.util.Promise;
 import ocean.io.device.File;
-import ocean.util.log.Logger;
 import dlsnode.util.aio.JobNotification;
 import ocean.core.Verify;
 import ocean.core.array.Mutation;
-
-/*******************************************************************************
-
-    Static module logger
-
-*******************************************************************************/
-
-private Logger log;
-static this ( )
-{
-    log = Log.lookup("dlsnode.storage.protocol.StorageProtocolLegacy");
-}
 
 /******************************************************************************
 

--- a/src/dlsnode/storage/protocol/StorageProtocolV1.d
+++ b/src/dlsnode/storage/protocol/StorageProtocolV1.d
@@ -103,7 +103,7 @@ scope class StorageProtocolV1: IStorageProtocol
         if (header_buf.calcParity() != 0)
         {
             // Record header is corrupted. Report that there are no more records
-            log.warn("Record header parity check failed. Will not read any more "
+            log.warn("Record header parity check failed. Will not read any more " ~
                 "records from this bucket file. File: {}, position: {}",
                 file.file_path, file.file_pos);
 
@@ -179,7 +179,7 @@ scope class StorageProtocolV1: IStorageProtocol
         if (parity != 0)
         {
             // Record header is corrupted. Report that there are no more records
-            log.warn("Record header parity check failed. Will not read any more "
+            log.warn("Record header parity check failed. Will not read any more " ~
                 "records from this bucket file.");
 
             throw .parity_exception;

--- a/src/dlsredist/main.d
+++ b/src/dlsredist/main.d
@@ -113,11 +113,11 @@ DLS. The standard use case when adding a new nodes to DLS is as follows:
     public override void setupArgs ( IApplication app, Arguments args )
     {
         args("src").aliased('S').required().params(1).
-            help("File describing DLS -- should contain the address/port of "
+            help("File describing DLS -- should contain the address/port of " ~
                  "all source nodes");
 
         args("dst").aliased('D').required().params(1).
-            help("File describing destination nodes -- should contain the "
+            help("File describing destination nodes -- should contain the " ~
                  "address/port of all destination nodes");
 
         args("fraction").required().aliased('f').params(1).

--- a/src/dlsredist/main.d
+++ b/src/dlsredist/main.d
@@ -66,6 +66,8 @@ int main ( istring[] args )
 
 public class DlsRedist: CliApp
 {
+    import ocean.text.Arguments : Arguments;
+
     /**************************************************************************
 
         EpollSelectDispatcher instance.


### PR DESCRIPTION
This stops using dmd-transitional (the upstream is good enough until proven otherwise), fixes most of the deprecations comming from DLS node and removes static constructor circle issue.