### PR TITLE
Replace notifempty with ifempty in logrotate config

### DIFF
--- a/deploy/logrotate/dlsnode-logs
+++ b/deploy/logrotate/dlsnode-logs
@@ -13,7 +13,7 @@
 	maxage 60
 
 	missingok
-	notifempty
+	ifempty
 	delaycompress
 	compress
 	maxsize 500M


### PR DESCRIPTION
With notifempty, if the base some.log file is empty, none of the
some.log.n* will be rotated either.