### PR TITLE
Use the correct bintray repo to upload the package to

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ jobs:
               - beaver dlang install
               - beaver dlang make
               - beaver dlang make pkg
-              - beaver bintray upload -d sociomantic-tsunami/nodes/dhtnode build/production/pkg/*.deb
+              - beaver bintray upload -d sociomantic-tsunami/nodes/dlsnode build/production/pkg/*.deb
 
     include:
         # Test matrix


### PR DESCRIPTION
Previously, DLS node was uploading the package to dhtnode's
repository.