### PR TITLE
Set PKG_SUFFIX from Config.mak

### DIFF
--- a/Config.mak
+++ b/Config.mak
@@ -1,0 +1,1 @@
+PKG_SUFFIX ?= -d$(DVER)


### PR DESCRIPTION
This adds Config.mak which sets PKG_SUFFIX for the D1/D2 build,
based on DVER.