### PR TITLE
Replace all remaining imports of ocean.transition

### DIFF
--- a/integrationtest/dlstest/main.d
+++ b/integrationtest/dlstest/main.d
@@ -16,8 +16,8 @@ module integrationtest.dlstest.main;
 
 *******************************************************************************/
 
-import ocean.transition;
 import dlstest.TestRunner;
+import ocean.meta.types.Qualifiers : istring;
 import turtle.runner.Runner;
 
 /*******************************************************************************

--- a/integrationtest/versioning/cases/TestEmptyBuckets.d
+++ b/integrationtest/versioning/cases/TestEmptyBuckets.d
@@ -11,7 +11,6 @@ module integrationtest.versioning.cases.TestEmptyBuckets;
 import integrationtest.versioning.DlsVersioningCase;
 
 import ocean.core.array.Search;
-import ocean.transition;
 import ocean.core.Test;
 
 /******************************************************************************

--- a/integrationtest/versioning/cases/TestLegacy.d
+++ b/integrationtest/versioning/cases/TestLegacy.d
@@ -11,7 +11,6 @@ module integrationtest.versioning.cases.TestLegacy;
 import integrationtest.versioning.DlsVersioningCase;
 
 import ocean.core.array.Search;
-import ocean.transition;
 import ocean.core.Test;
 
 /******************************************************************************
@@ -37,6 +36,8 @@ class GetAllLegacy: DlsVersioningCase
 
     public override void run ( )
     {
+        import ocean.meta.types.Qualifiers : cstring;
+
         // A single bucket file in the legacy format is copied into the test DLS
         // node's data folder (see DlsVersioningRunner.copyFiles()). We can then
         // perform tests to check that the DLS can read it properly.

--- a/integrationtest/versioning/cases/TestLegacyWrite.d
+++ b/integrationtest/versioning/cases/TestLegacyWrite.d
@@ -11,7 +11,6 @@ module integrationtest.versioning.cases.TestLegacyWrite;
 import integrationtest.versioning.DlsVersioningCase;
 
 import ocean.core.array.Search;
-import ocean.transition;
 import ocean.core.Test;
 
 /******************************************************************************
@@ -37,6 +36,8 @@ class GetAllLegacy: DlsVersioningCase
 
     public override void run ( )
     {
+        import ocean.meta.types.Qualifiers : cstring;
+
         // A single bucket file in the legacy format is copied into the test DLS
         // node's data folder (see DlsVersioningRunner.copyFiles()). We can then
         // perform tests to check that the DLS can write and read it properly.
@@ -50,7 +51,7 @@ class GetAllLegacy: DlsVersioningCase
             0x0000000057275810: ["Oh, yes indeed."]
         ];
 
-        cstring[][hash_t] new_records = 
+        cstring[][hash_t] new_records =
         [
             0x0000000057275813: ["test1"],
             0x0000000057275814: ["test2"],
@@ -78,7 +79,7 @@ class GetAllLegacy: DlsVersioningCase
                 this.dls.put(this.test_channel, k, rec);
             }
         }
-        
+
         // Do a GetAll to retrieve them all
         auto fetched = this.dls.getAll(this.test_channel);
 

--- a/integrationtest/versioning/cases/TestMixedBuckets.d
+++ b/integrationtest/versioning/cases/TestMixedBuckets.d
@@ -11,7 +11,6 @@ module integrationtest.versioning.cases.TestMixedBuckets;
 import integrationtest.versioning.DlsVersioningCase;
 
 import ocean.core.array.Search;
-import ocean.transition;
 import ocean.core.Test;
 
 /******************************************************************************
@@ -38,6 +37,8 @@ class GetAllMixedBuckets: DlsVersioningCase
 
     public override void run ( )
     {
+        import ocean.meta.types.Qualifiers : cstring;
+
         // One bucket file in the legacy format and one in the v1 format are
         // copied into the test DLS node's data folder as a single channel
         // (see DlsVersioningRunner.copyFiles()). We can then perform tests to

--- a/integrationtest/versioning/cases/TestParityBroken.d
+++ b/integrationtest/versioning/cases/TestParityBroken.d
@@ -11,7 +11,6 @@ module integrationtest.versioning.cases.TestParityBroken;
 import integrationtest.versioning.DlsVersioningCase;
 
 import ocean.core.array.Search;
-import ocean.transition;
 import ocean.core.Test;
 
 /******************************************************************************
@@ -38,6 +37,8 @@ class GetAllParityBroken: DlsVersioningCase
 
     public override void run ( )
     {
+        import ocean.meta.types.Qualifiers : cstring;
+
         // A single bucket file in the v1 format, with partity errors, is copied
         // into the test DLS node's data folder (see
         // DlsVersioningRunner.copyFiles()). We can then perform tests to check

--- a/integrationtest/versioning/cases/TestParityFine.d
+++ b/integrationtest/versioning/cases/TestParityFine.d
@@ -11,7 +11,6 @@ module integrationtest.versioning.cases.TestParityFine;
 import integrationtest.versioning.DlsVersioningCase;
 
 import ocean.core.array.Search;
-import ocean.transition;
 import ocean.core.Test;
 
 /******************************************************************************
@@ -37,6 +36,8 @@ class GetAllParityFine: DlsVersioningCase
 
     public override void run ( )
     {
+        import ocean.meta.types.Qualifiers : cstring;
+
         // A single bucket file in the v1 format is copied into the test DLS
         // node's data folder (see DlsVersioningRunner.copyFiles()). We can then
         // perform tests to check that the DLS can read it properly.

--- a/integrationtest/versioning/cases/TestVersionOneWrite.d
+++ b/integrationtest/versioning/cases/TestVersionOneWrite.d
@@ -11,7 +11,6 @@ module integrationtest.versioning.cases.TestVersionOneWrite;
 import integrationtest.versioning.DlsVersioningCase;
 
 import ocean.core.array.Search;
-import ocean.transition;
 import ocean.core.Test;
 
 /******************************************************************************
@@ -37,6 +36,8 @@ class GetAllLegacy: DlsVersioningCase
 
     public override void run ( )
     {
+        import ocean.meta.types.Qualifiers : cstring;
+
         // A single bucket file in the new format is copied into the test DLS
         // node's data folder (see DlsVersioningRunner.copyFiles()). We can then
         // perform tests to check that the DLS can write and read it properly.
@@ -54,7 +55,7 @@ class GetAllLegacy: DlsVersioningCase
             0x0000000057275475: ["bye"]
         ];
 
-        cstring[][hash_t] new_records = 
+        cstring[][hash_t] new_records =
         [
             0x0000000057275476: ["test1"],
             0x0000000057275477: ["test2"],
@@ -86,7 +87,7 @@ class GetAllLegacy: DlsVersioningCase
                 this.dls.put(this.test_channel, k, rec);
             }
         }
-        
+
         // Do a GetAll to retrieve them all
         auto fetched = this.dls.getAll(this.test_channel);
 

--- a/integrationtest/versioning/main.d
+++ b/integrationtest/versioning/main.d
@@ -15,8 +15,6 @@ module integrationtest.versioning.main;
 
 *******************************************************************************/
 
-import ocean.transition;
-
 import turtle.runner.Runner;
 
 import integrationtest.versioning.cases.TestEmptyBuckets;
@@ -25,6 +23,8 @@ import integrationtest.versioning.cases.TestLegacyWrite;
 import integrationtest.versioning.cases.TestVersionOneWrite;
 import integrationtest.versioning.cases.TestParityFine;
 import integrationtest.versioning.cases.TestParityBroken;
+
+import ocean.meta.types.Qualifiers : istring;
 
 
 /*******************************************************************************

--- a/src/dlsnode/app/config/ServerConfig.d
+++ b/src/dlsnode/app/config/ServerConfig.d
@@ -12,7 +12,6 @@
 
 module dlsnode.app.config.ServerConfig;
 
-import ocean.transition;
 
 
 /*******************************************************************************
@@ -33,6 +32,8 @@ import ConfigReader = ocean.util.config.ConfigFiller;
 
 public class ServerConfig
 {
+    import ocean.meta.types.Qualifiers : mstring;
+
     ConfigReader.Required!(mstring) address;
 
     ConfigReader.Required!(ushort) port;

--- a/src/dlsnode/connection/SharedResources.d
+++ b/src/dlsnode/connection/SharedResources.d
@@ -30,8 +30,6 @@ module dlsnode.connection.SharedResources;
 
 import swarm.common.connection.ISharedResources;
 
-import ocean.transition;
-
 public import ocean.io.select.client.FiberSelectEvent;
 
 public import dlsnode.util.aio.EventFDJobNotification;
@@ -70,6 +68,8 @@ public alias PCRE.CompiledRegex CompiledRegex;
 
 public struct ConnectionResources
 {
+    import ocean.meta.types.Qualifiers : cstring, mstring;
+
     mstring channel_buffer;
     mstring key_buffer;
     mstring key2_buffer;

--- a/src/dlsnode/connection/neo/SharedResources.d
+++ b/src/dlsnode/connection/neo/SharedResources.d
@@ -13,8 +13,6 @@
 
 module dlsnode.connection.neo.SharedResources;
 
-import ocean.transition;
-
 /*******************************************************************************
 
     Resources owned by the node which are needed by the request handlers.

--- a/src/dlsnode/main.d
+++ b/src/dlsnode/main.d
@@ -20,9 +20,8 @@ module dlsnode.main;
 
 *******************************************************************************/
 
-import ocean.transition;
-
 import ocean.io.select.client.SelectEvent;
+import ocean.meta.types.Qualifiers : istring;
 import ocean.util.app.DaemonApp;
 
 // FIXME: this import is static in order to resolve conflict with
@@ -39,9 +38,7 @@ import core.stdc.string;
 import core.sys.posix.unistd;
 import core.sys.posix.sys.stat;
 import core.sys.posix.fcntl;
-import ocean.transition;
 
-import ocean.transition;
 
 /*******************************************************************************
 

--- a/src/dlsnode/neo/request/GetRange.d
+++ b/src/dlsnode/neo/request/GetRange.d
@@ -22,7 +22,6 @@ import ocean.text.regex.PCRE;
 import ocean.text.Search;
 
 import ocean.core.Array;
-import ocean.transition;
 import ocean.core.TypeConvert: downcast;
 
 import dlsnode.util.aio.DelegateJobNotification;
@@ -53,6 +52,7 @@ scope class GetRangeImpl_v2: GetRangeProtocol_v2
     import dlsnode.storage.StorageEngine;
     import dlsnode.storage.iterator.NeoStorageEngineStepIterator;
     import core.stdc.time;
+    import ocean.meta.types.Qualifiers : Const, cstring, mstring;
 
     /***************************************************************************
 

--- a/src/dlsnode/neo/request/Put.d
+++ b/src/dlsnode/neo/request/Put.d
@@ -19,7 +19,6 @@ import swarm.neo.request.Command;
 import dlsproto.common.RequestCodes;
 import dlsnode.connection.neo.SharedResources;
 
-import ocean.transition;
 import ocean.core.TypeConvert: downcast;
 
 /*******************************************************************************
@@ -34,6 +33,7 @@ scope class PutImpl_v1: PutProtocol_v1
     import dlsnode.storage.StorageChannels;
     import dlsnode.storage.StorageEngine;
     import core.stdc.time;
+    import ocean.meta.types.Qualifiers : cstring, mstring;
 
     /***************************************************************************
 

--- a/src/dlsnode/node/DlsNode.d
+++ b/src/dlsnode/node/DlsNode.d
@@ -22,8 +22,8 @@ module dlsnode.node.DlsNode;
 
 import swarm.node.model.NeoChannelsNode : ChannelsNodeBase;
 
-import ocean.transition;
 import ocean.core.TypeConvert;
+import ocean.meta.types.Qualifiers : istring, mstring;
 
 import dlsnode.node.IDlsNodeInfo;
 

--- a/src/dlsnode/request/GetAllFilterRequest.d
+++ b/src/dlsnode/request/GetAllFilterRequest.d
@@ -19,7 +19,6 @@ module dlsnode.request.GetAllFilterRequest;
 *******************************************************************************/
 
 import Protocol = dlsproto.node.request.GetAllFilter;
-import ocean.transition;
 
 /*******************************************************************************
 
@@ -32,6 +31,7 @@ scope class GetAllFilterRequest : Protocol.GetAllFilter
     import dlsnode.request.model.IterationMixin;
     import dlsnode.request.model.ConstructorMixin;
 
+    import ocean.meta.types.Qualifiers : Const, cstring;
     import ocean.text.Search;
 
     /***************************************************************************

--- a/src/dlsnode/request/GetChannelSizeRequest.d
+++ b/src/dlsnode/request/GetChannelSizeRequest.d
@@ -19,7 +19,6 @@ module dlsnode.request.GetChannelSizeRequest;
 *******************************************************************************/
 
 import Protocol = dlsproto.node.request.GetChannelSize;
-import ocean.transition;
 
 /*******************************************************************************
 

--- a/src/dlsnode/request/GetChannelsRequest.d
+++ b/src/dlsnode/request/GetChannelsRequest.d
@@ -18,7 +18,6 @@ module dlsnode.request.GetChannelsRequest;
 
 *******************************************************************************/
 
-import ocean.transition;
 import Protocol = dlsproto.node.request.GetChannels;
 
 /*******************************************************************************
@@ -30,6 +29,7 @@ import Protocol = dlsproto.node.request.GetChannels;
 public scope class GetChannelsRequest : Protocol.GetChannels
 {
     import dlsnode.request.model.ConstructorMixin;
+    import ocean.meta.types.Qualifiers : cstring;
 
     /***************************************************************************
 

--- a/src/dlsnode/request/GetRangeFilterRequest.d
+++ b/src/dlsnode/request/GetRangeFilterRequest.d
@@ -19,7 +19,6 @@ module dlsnode.request.GetRangeFilterRequest;
 *******************************************************************************/
 
 import Protocol = dlsproto.node.request.GetRangeFilter;
-import ocean.transition;
 
 /*******************************************************************************
 
@@ -32,6 +31,7 @@ scope class GetRangeFilterRequest : Protocol.GetRangeFilter
     import dlsnode.request.model.IterationMixin;
     import dlsnode.request.model.ConstructorMixin;
 
+    import ocean.meta.types.Qualifiers : Const, cstring;
     import ocean.text.Search;
 
     /***************************************************************************
@@ -52,7 +52,7 @@ scope class GetRangeFilterRequest : Protocol.GetRangeFilter
     mixin RequestConstruction!();
 
     /***************************************************************************
-    
+
         Predicate that accepts records that match the specified range and filter
 
     ***************************************************************************/
@@ -72,7 +72,7 @@ scope class GetRangeFilterRequest : Protocol.GetRangeFilter
     mixin ChannelIteration!(resources, IterationKind.Ranged, filterPredicate);
 
     /***************************************************************************
-        
+
         Initialized regex match based on provided filter string
 
         Params:

--- a/src/dlsnode/request/GetRangeRegexRequest.d
+++ b/src/dlsnode/request/GetRangeRegexRequest.d
@@ -22,7 +22,6 @@ import Protocol = dlsproto.node.request.GetRangeRegex;
 import ocean.text.regex.PCRE;
 
 import ocean.util.log.Logger;
-import ocean.transition;
 
 /*******************************************************************************
 
@@ -49,6 +48,7 @@ scope class GetRangeRegexRequest : Protocol.GetRangeRegex
 
     import dlsproto.client.legacy.DlsConst;
 
+    import ocean.meta.types.Qualifiers : Const, cstring;
     import ocean.text.Search;
 
     /***************************************************************************

--- a/src/dlsnode/request/PutBatchRequest.d
+++ b/src/dlsnode/request/PutBatchRequest.d
@@ -21,7 +21,6 @@ module dlsnode.request.PutBatchRequest;
 import Protocol = dlsproto.node.request.PutBatch;
 
 import ocean.util.log.Logger;
-import ocean.transition;
 
 /*******************************************************************************
 
@@ -47,6 +46,7 @@ public scope class PutBatchRequest : Protocol.PutBatch
     import dlsnode.request.model.ConstructorMixin;
 
     import ocean.core.TypeConvert : downcast;
+    import ocean.meta.types.Qualifiers : cstring;
 
     /***************************************************************************
 

--- a/src/dlsnode/request/PutRequest.d
+++ b/src/dlsnode/request/PutRequest.d
@@ -19,7 +19,6 @@ module dlsnode.request.PutRequest;
 *******************************************************************************/
 
 import Protocol = dlsproto.node.request.Put;
-import ocean.transition;
 
 /*******************************************************************************
 
@@ -33,6 +32,7 @@ public scope class PutRequest : Protocol.Put
     import dlsnode.storage.StorageEngine;
 
     import ocean.core.TypeConvert : downcast;
+    import ocean.meta.types.Qualifiers : cstring;
     import swarm.util.RecordBatcher;
 
     /***************************************************************************

--- a/src/dlsnode/request/RedistributeRequest.d
+++ b/src/dlsnode/request/RedistributeRequest.d
@@ -283,7 +283,7 @@ scope class RedistributeRequest: Protocol.Redistribute
         // Rename the file to .tmp, making it inaccessible to the storage engine
         scope original_path = new FilePath(bucket_path);
         tmp_file_path.length = 0;
-        enableStomping(tmp_file_path);
+        assumeSafeAppend(tmp_file_path);
         sformat(tmp_file_path, "{}.tmp", bucket_path);
         original_path.rename(tmp_file_path);
 

--- a/src/dlsnode/request/RedistributeRequest.d
+++ b/src/dlsnode/request/RedistributeRequest.d
@@ -21,8 +21,6 @@ module dlsnode.request.RedistributeRequest;
 
 import Protocol = dlsproto.node.request.Redistribute;
 
-import ocean.transition;
-
 import ocean.util.log.Logger;
 
 /******************************************************************************
@@ -61,7 +59,7 @@ scope class RedistributeRequest: Protocol.Redistribute
     import ocean.core.Array: copy;
     import ocean.core.Buffer;
     import ocean.core.TypeConvert : downcast;
-
+    import ocean.meta.types.Qualifiers : cstring, mstring;
     import ocean.text.convert.Formatter;
     import ocean.io.FilePath;
     import ocean.io.device.File;

--- a/src/dlsnode/request/RemoveChannelRequest.d
+++ b/src/dlsnode/request/RemoveChannelRequest.d
@@ -19,7 +19,6 @@ module dlsnode.request.RemoveChannelRequest;
 *******************************************************************************/
 
 import Protocol = dlsproto.node.request.RemoveChannel;
-import ocean.transition;
 
 /*******************************************************************************
 
@@ -30,6 +29,7 @@ import ocean.transition;
 public scope class RemoveChannelRequest : Protocol.RemoveChannel
 {
     import dlsnode.request.model.ConstructorMixin;
+    import ocean.meta.types.Qualifiers : cstring;
 
     /***************************************************************************
 

--- a/src/dlsnode/request/model/IterationMixin.d
+++ b/src/dlsnode/request/model/IterationMixin.d
@@ -12,8 +12,6 @@
 
 module dlsnode.request.model.IterationMixin;
 
-import ocean.transition;
-
 /*******************************************************************************
 
     Indicates whether to mixin code for iterating over the complete channel or
@@ -43,10 +41,10 @@ enum IterationKind
 public template ChannelIteration ( alias resources, IterationKind kind,
     alias predicate = alwaysTrue )
 {
-    import ocean.transition;
     import dlsnode.storage.StorageChannels;
     import dlsnode.storage.StorageEngine;
     import dlsnode.storage.iterator.StorageEngineStepIterator;
+    import ocean.meta.types.Qualifiers : cstring;
 
     /***************************************************************************
 

--- a/src/dlsnode/storage/BucketFile.d
+++ b/src/dlsnode/storage/BucketFile.d
@@ -14,11 +14,9 @@
 
 module dlsnode.storage.BucketFile;
 
-import ocean.transition;
 import ocean.core.Verify;
 
 import ocean.io.model.IConduit;
-import ocean.transition;
 import dlsnode.util.aio.AsyncIO;
 import dlsnode.util.aio.JobNotification;
 
@@ -50,6 +48,7 @@ public class BucketFile: OutputStream
     import ocean.core.Enforce;
     import ocean.io.device.File;
     import ocean.io.serialize.SimpleStreamSerializer;
+    import ocean.meta.types.Qualifiers : Const, cstring, istring, mstring;
     import ocean.sys.ErrnoException;
 
     import DlsInputBuffer = dlsnode.storage.util.InputBuffer;

--- a/src/dlsnode/storage/BufferedBucketOutput.d
+++ b/src/dlsnode/storage/BufferedBucketOutput.d
@@ -24,8 +24,6 @@ module dlsnode.storage.BufferedBucketOutput;
 
  ******************************************************************************/
 
-import ocean.transition;
-
 import dlsnode.storage.BucketFile;
 import dlsnode.storage.FileSystemLayout;
 import dlsnode.storage.Record;
@@ -66,6 +64,7 @@ public class BufferedBucketOutput
 {
     import dlsnode.storage.checkpoint.CheckpointService;
     import ocean.core.Buffer;
+    import ocean.meta.types.Qualifiers : cstring, mstring;
 
     /**************************************************************************
 

--- a/src/dlsnode/storage/FileSystemLayout.d
+++ b/src/dlsnode/storage/FileSystemLayout.d
@@ -533,7 +533,7 @@ public class FileSystemLayout
                 auto bucket_name = Hash.intToHex(found_bucket, bucket_name_buf);
 
                 path.length = 0;
-                enableStomping(path);
+                assumeSafeAppend(path);
                 sformat(path, "{}/{}/{}", base_dir, slot_name,
                     bucket_name);
 

--- a/src/dlsnode/storage/FileSystemLayout.d
+++ b/src/dlsnode/storage/FileSystemLayout.d
@@ -74,8 +74,6 @@ module dlsnode.storage.FileSystemLayout;
 
 *******************************************************************************/
 
-import ocean.transition;
-
 import Hash = swarm.util.Hash;
 
 import dlsnode.storage.BucketFile;
@@ -95,6 +93,8 @@ import ocean.io.device.File;
 import ocean.io.FilePath;
 
 import ocean.core.ExceptionDefinitions: IOException;
+
+import ocean.meta.types.Qualifiers : cstring, istring, mstring;
 
 import Integer = ocean.text.convert.Integer : toUlong;
 
@@ -125,6 +125,8 @@ static this ( )
 
 public class FileSystemLayout
 {
+    import ocean.core.TypeConvert : assumeUnique;
+
     /**************************************************************************
 
         Private constructor to prevent instantiation. The public interface of

--- a/src/dlsnode/storage/StorageChannels.d
+++ b/src/dlsnode/storage/StorageChannels.d
@@ -28,8 +28,6 @@ import ocean.util.log.Logger;
 
 import ocean.io.select.client.FiberSelectEvent;
 
-import ocean.transition;
-
 /*******************************************************************************
 
     Static module logger
@@ -65,7 +63,7 @@ public class StorageChannels : IStorageChannelsTemplate!(StorageEngine)
     import ocean.io.select.client.FiberSelectEvent;
 
     import ocean.io.FilePath;
-
+    import ocean.meta.types.Qualifiers : cstring;
     import ocean.sys.Environment;
 
     debug import ocean.io.Stdout : Stderr;

--- a/src/dlsnode/storage/StorageEngine.d
+++ b/src/dlsnode/storage/StorageEngine.d
@@ -31,8 +31,6 @@ import dlsnode.util.aio.AsyncIO;
 import core.stdc.time;
 import Hash = swarm.util.Hash;
 
-import ocean.transition;
-
 
 /*******************************************************************************
 
@@ -63,6 +61,7 @@ public class StorageEngine : IStorageEngine
     import ocean.core.Array : concat;
     import ocean.core.Enforce;
     import ocean.io.FilePath;
+    import ocean.meta.types.Qualifiers : cstring, mstring;
 
     import Path = ocean.io.Path;
 

--- a/src/dlsnode/storage/checkpoint/CheckpointFile.d
+++ b/src/dlsnode/storage/checkpoint/CheckpointFile.d
@@ -29,7 +29,6 @@
 module dlsnode.storage.checkpoint.CheckpointFile;
 
 import ocean.util.log.Logger;
-import ocean.transition;
 
 /******************************************************************************
 
@@ -56,6 +55,7 @@ class CheckpointFile
     import ocean.sys.ErrnoException;
     import ocean.core.Array;
     import ocean.io.device.File;
+    import ocean.meta.types.Qualifiers : cstring, istring, mstring;
 
     import dlsnode.util.PosixFile;
     import dlsnode.storage.FileSystemLayout;

--- a/src/dlsnode/storage/checkpoint/CheckpointService.d
+++ b/src/dlsnode/storage/checkpoint/CheckpointService.d
@@ -19,10 +19,8 @@ module dlsnode.storage.checkpoint.CheckpointService;
 
 import dlsnode.util.aio.JobNotification;
 import ocean.core.Test;
-import ocean.transition;
-
+import ocean.meta.types.Qualifiers : cstring, istring, mstring;
 import ocean.util.log.Logger;
-import ocean.transition;
 
 version (UnitTest)
 {

--- a/src/dlsnode/storage/iterator/NeoStorageEngineStepIterator.d
+++ b/src/dlsnode/storage/iterator/NeoStorageEngineStepIterator.d
@@ -22,9 +22,6 @@
 
 module dlsnode.storage.iterator.NeoStorageEngineStepIterator;
 
-import ocean.transition;
-
-
 import dlsnode.storage.StorageEngine;
 
 import dlsnode.util.aio.AsyncIO;
@@ -47,6 +44,7 @@ public class NeoStorageEngineStepIterator
 
     import ocean.core.Buffer;
     import ocean.io.device.File;
+    import ocean.meta.types.Qualifiers : mstring;
 
     /***************************************************************************
 

--- a/src/dlsnode/storage/iterator/StorageEngineFileIterator.d
+++ b/src/dlsnode/storage/iterator/StorageEngineFileIterator.d
@@ -13,8 +13,6 @@
 
 module dlsnode.storage.iterator.StorageEngineFileIterator;
 
-import ocean.transition;
-
 
 /*******************************************************************************
 
@@ -26,6 +24,7 @@ public class StorageEngineFileIterator
 {
     import dlsnode.storage.FileSystemLayout : FileSystemLayout;
     import dlsnode.storage.StorageEngine;
+    import ocean.meta.types.Qualifiers : cstring, mstring;
 
     /***************************************************************************
 

--- a/src/dlsnode/storage/iterator/StorageEngineStepIterator.d
+++ b/src/dlsnode/storage/iterator/StorageEngineStepIterator.d
@@ -25,8 +25,6 @@
 
 module dlsnode.storage.iterator.StorageEngineStepIterator;
 
-import ocean.transition;
-
 
 /*******************************************************************************
 
@@ -55,6 +53,7 @@ public class StorageEngineStepIterator: IStorageEngineStepIterator
 
     import ocean.core.Buffer;
     import ocean.io.device.File;
+    import ocean.meta.types.Qualifiers : cstring, mstring;
 
     import Hash = swarm.util.Hash;
 

--- a/src/dlsnode/storage/iterator/model/IStorageEngineStepIterator.d
+++ b/src/dlsnode/storage/iterator/model/IStorageEngineStepIterator.d
@@ -26,10 +26,10 @@
 module dlsnode.storage.iterator.model.IStorageEngineStepIterator;
 import dlsnode.util.aio.JobNotification;
 
-import ocean.transition;
-
 interface IStorageEngineStepIterator
 {
+    import ocean.meta.types.Qualifiers : cstring;
+
     /***************************************************************************
 
         Initialises the iterator to iterate over all records in the

--- a/src/dlsnode/storage/protocol/StorageProtocolLegacy.d
+++ b/src/dlsnode/storage/protocol/StorageProtocolLegacy.d
@@ -12,8 +12,6 @@
 
 module dlsnode.storage.protocol.StorageProtocolLegacy;
 
-import ocean.transition;
-
 import dlsnode.storage.protocol.model.IStorageProtocol;
 import dlsnode.storage.util.Promise;
 import ocean.io.device.File;
@@ -38,6 +36,7 @@ import ocean.core.array.Mutation;
 
 scope class StorageProtocolLegacy: IStorageProtocol
 {
+    import ocean.meta.types.Qualifiers : cstring, mstring;
 
     /**************************************************************************
 

--- a/src/dlsnode/storage/protocol/StorageProtocolV1.d
+++ b/src/dlsnode/storage/protocol/StorageProtocolV1.d
@@ -13,8 +13,6 @@
 
 module dlsnode.storage.protocol.StorageProtocolV1;
 
-import ocean.transition;
-
 import dlsnode.storage.protocol.model.IStorageProtocol;
 import ocean.io.device.File;
 import ocean.util.log.Logger;
@@ -68,6 +66,7 @@ static this ( )
 
 scope class StorageProtocolV1: IStorageProtocol
 {
+    import ocean.meta.types.Qualifiers : cstring, mstring;
 
     /**************************************************************************
 

--- a/src/dlsnode/storage/protocol/model/IStorageProtocol.d
+++ b/src/dlsnode/storage/protocol/model/IStorageProtocol.d
@@ -13,8 +13,6 @@
 
 module dlsnode.storage.protocol.model.IStorageProtocol;
 
-import ocean.transition;
-
 public import dlsnode.storage.Record;
 public import dlsnode.storage.BucketFile;
 public import ocean.io.stream.Buffered;
@@ -25,6 +23,8 @@ import dlsnode.storage.util.Promise;
 
 interface IStorageProtocol
 {
+    import ocean.meta.types.Qualifiers : cstring, mstring;
+
     /**************************************************************************
 
         Reads next record header from the file, if any.

--- a/src/dlsnode/storage/util/InputBuffer.d
+++ b/src/dlsnode/storage/util/InputBuffer.d
@@ -14,8 +14,6 @@
 
 module dlsnode.storage.util.InputBuffer;
 
-import ocean.transition;
-
 import core.sys.posix.sys.types;
 import ocean.core.Buffer;
 import ocean.core.Verify;

--- a/src/dlsnode/storage/util/InputBuffer.d
+++ b/src/dlsnode/storage/util/InputBuffer.d
@@ -258,7 +258,7 @@ struct InputBuffer
         if (this.buffer.length < promise.dataMissing)
         {
             this.buffer.length = promise.dataMissing;
-            enableStomping(this.buffer);
+            assumeSafeAppend(this.buffer);
         }
 
         // Set the final destination buffer to read from

--- a/src/dlsnode/storage/util/Promise.d
+++ b/src/dlsnode/storage/util/Promise.d
@@ -21,7 +21,6 @@
 
 module dlsnode.storage.util.Promise;
 
-import ocean.transition;
 import ocean.core.Verify;
 import ocean.core.Traits;
 import core.sys.posix.sys.types;

--- a/src/dlsnode/storage/util/Promise.d
+++ b/src/dlsnode/storage/util/Promise.d
@@ -92,7 +92,7 @@ public struct Promise
     public void reset (size_t num_bytes)
     {
         this.data_buffer.length = num_bytes;
-        enableStomping(this.data_buffer);
+        assumeSafeAppend(this.data_buffer);
         this.reset();
     }
 

--- a/src/dlsnode/util/PosixFile.d
+++ b/src/dlsnode/util/PosixFile.d
@@ -13,8 +13,8 @@
 
 module dlsnode.util.PosixFile;
 
+import ocean.meta.types.Qualifiers : cstring, istring;
 import ocean.sys.ErrnoException;
-import ocean.transition;
 
 class PosixFile
 {
@@ -27,7 +27,6 @@ class PosixFile
     import core.stdc.errno: EINTR, errno;
 
     import ocean.io.FilePath;
-
     import ocean.util.log.Logger;
 
     /***************************************************************************

--- a/src/dlsnode/util/aio/AsyncIO.d
+++ b/src/dlsnode/util/aio/AsyncIO.d
@@ -27,8 +27,6 @@
 
 module dlsnode.util.aio.AsyncIO;
 
-import ocean.transition;
-
 import core.stdc.errno;
 import core.sys.posix.semaphore;
 import core.sys.posix.pthread;

--- a/src/dlsnode/util/aio/AsyncIO.d
+++ b/src/dlsnode/util/aio/AsyncIO.d
@@ -157,7 +157,7 @@ class AsyncIO
                 &unlock_mutex);
 
         job.recv_buffer.length = buf.length;
-        enableStomping(job.recv_buffer);
+        assumeSafeAppend(job.recv_buffer);
         job.fd = fd;
         job.suspended_job = suspended_job;
         job.offset = offset;
@@ -254,7 +254,7 @@ class AsyncIO
                     &unlock_mutex);
 
             job.recv_buffer.length = buf.length;
-            enableStomping(job.recv_buffer);
+            assumeSafeAppend(job.recv_buffer);
 
             job.fd = fd;
             job.offset = offset;

--- a/src/dlsnode/util/aio/internal/AioScheduler.d
+++ b/src/dlsnode/util/aio/internal/AioScheduler.d
@@ -34,7 +34,6 @@
 
 module dlsnode.util.aio.internal.AioScheduler;
 
-import ocean.transition;
 import ocean.io.select.client.SelectEvent;
 
 /// Ditto

--- a/src/dlsnode/util/aio/internal/JobQueue.d
+++ b/src/dlsnode/util/aio/internal/JobQueue.d
@@ -389,7 +389,7 @@ public static class JobQueue
         free_job.is_slot_free = false;
         free_job.owner_queue = this;
         free_job.finish_callback_dgs.length = 0;
-        enableStomping(free_job.finish_callback_dgs);
+        assumeSafeAppend(free_job.finish_callback_dgs);
         free_job.ret_val = null;
         free_job.errno_val = null;
 

--- a/src/dlsnode/util/aio/internal/JobQueue.d
+++ b/src/dlsnode/util/aio/internal/JobQueue.d
@@ -12,8 +12,6 @@
 
 module dlsnode.util.aio.internal.JobQueue;
 
-import ocean.transition;
-
 import core.stdc.errno;
 import core.stdc.stdint;
 import core.sys.posix.unistd;

--- a/src/dlsredist/main.d
+++ b/src/dlsredist/main.d
@@ -23,13 +23,12 @@ module dlsredist.main;
 
 import Version;
 
-import ocean.transition;
-
 import dlsredist.client.DlsClient;
 
 import ocean.core.Enforce: enforce;
 import ocean.io.Stdout;
 import ocean.io.select.EpollSelectDispatcher;
+import ocean.meta.types.Qualifiers : cstring, istring, mstring;
 import ocean.util.app.CliApp;
 
 import swarm.Const;


### PR DESCRIPTION
The D2 transition is done, so we can ditch this module:
  
  * calls to `enableStomping` have been replaced with `assumeSafeAppend`

  * `istring`, `cstring`, `mstring` and `Const` are now all imported from `ocean.meta.types.Qualifiers`

  * `assumeUnique` is now imported from `ocean.core.TypeConvert`

In a few cases the `ocean.transition` import appears to be completely unused, in which case it has just been deleted.