### PR TITLE
Add Build.mak options to support more compiler and distro diversity

### DIFF
--- a/Build.mak
+++ b/Build.mak
@@ -1,4 +1,17 @@
-override DFLAGS += -w
+# check whether to build with position-independent code
+# (may be required to build on newer distro releases)
+ifeq ($(USE_PIC),1)
+	override DFLAGS += -fPIC
+endif
+
+# some D compilers are more picky than others, so tolerating
+# warnings may be necessary in order to build with them
+ifeq ($(ALLOW_WARNINGS), 1)
+	override DFLAGS += -wi
+else
+	override DFLAGS += -w
+endif
+
 override LDFLAGS += -llzo2 -lebtree -lrt -lgcrypt -lgpg-error -lglib-2.0
 
 $B/dlsnode: override LDFLAGS += -lpcre -lebtree


### PR DESCRIPTION
This patch adds a couple of little helpful build variables that may be of assistance when building on more recent distros, or with compilers other than `dmd-transitional`.

Ubuntu 18.04 (among other distros) expects position-independent code. The new `USE_PIC` build variable allows the user to request this if the compiler does not use the `-fPIC` flag by default (as is e.g. the case with `dmd-transitional`).

LDC appears to be a bit more strict than DMD when it comes to generating warnings.  The `ALLOW_WARNINGS` variable allow the user (or CI) to be a bit more forgiving of problems that may arise in library space and are therefore outside the app developer's immediate ability to correct.

When combined with the changes in PRs https://github.com/sociomantic-tsunami/dlsnode/pull/101 and https://github.com/sociomantic-tsunami/dlsnode/pull/102 this should make it possible to build `dhtnode` and run full integration tests using `ldmd2` instead of `dmd` or `dmd-transitional`:

```
ALLOW_WARNINGS=1 DC=ldmd2 make all test
```

For anyone interested, the warning triggered is related to `SmartUnion`, and only shows up with `ldmd2` (not with DMD with equivalent frontend version):

```
./submodules/ocean/src/ocean/core/SmartUnion.d-mixin-95(115): Warning: skipping definition of function ocean.core.SmartUnion.SmartUnion!(NotificationUnion).SmartUnion.opCall due to previous definition for the same mangled name: _D5ocean4core10SmartUnion__TQpTS8dlsproto6client7request3Put17NotificationUnionZQCp6opCallFNaNbNiNfS5swarm3neoQCr13NotifierTypes6NoInfoZSQFfQFcQFa__TQFgTQEsZQFo
```

Builds were tested with `dmd-transitional`, DMD 2.085.1 and LDC 1.15.0 (== frontend 2.085.1).