### PR TITLE
Add test builds with DMD 2.088.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,10 @@ jobs:
           env: DMD=2.078.* F=production COV=1
         - <<: *test-matrix
           env: DMD=2.078.* F=devel COV=1
+        - <<: *test-matrix
+          env: DMD=2.088.* F=production COV=1
+        - <<: *test-matrix
+          env: DMD=2.088.* F=devel COV=1
 
         # Test deployment docker image generation
         - stage: Test

--- a/src/dlsnode/connection/DlsConnectionHandler.d
+++ b/src/dlsnode/connection/DlsConnectionHandler.d
@@ -126,6 +126,8 @@ public class DlsConnectionSetupParams : ConnectionSetupParams
 public class DlsConnectionHandler
     : ConnectionHandlerTemplate!(DlsConst.Command)
 {
+    import ocean.meta.types.Qualifiers : cstring, mstring;
+
     /***************************************************************************
 
         Helper class to acquire and relinquish resources required by a request


### PR DESCRIPTION
This establishes that dlsnode can be built with the latest upstream DMD release, with no custom modifications.

No change has been made to production/deployment settings, but this will allow future code changes to be validated against the newest D frontend versions.  Note that this should extend also to other compilers (LDC or GDC) that can offer support for up to date frontend versions.

Note that the latest compiler versions (2.087 and 2.088) come with a lot of new deprecations, and remove a number of long-deprecated features.  Most relevant to dlsnode are:

* 2.087 deprecates the use of `scope` as a type constraint on class declarations:
  https://dlang.org/changelog/2.087.0.html#dep_scope_class

* 2.087 ends the deprecation phase for access checks, which may have some impact on builds that rely on implicit imports:
  https://dlang.org/changelog/2.087.0.html#remove_visibility

  - the first patch in this PR adds one missing import that appears to be uncovered by this change

* 2.088 deprecates D1 operator overloads (e.g. `opNeg`, `opAdd`) in favour of `opUnary`, `opBinary`, etc.:
  https://dlang.org/changelog/2.088.0.html#dep_d1_ops

For dlsnode, all the triggered deprecations appear to be in ocean, swarm and dlsproto rather than app code.