### PR TITLE
Drop compatibility for anything less than v2.092

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ before_install: git submodule update --init
 # Global environment variables
 env:
     global:
-        - DIST=xenial
+        - DIST=bionic
+        - COV=0
         # Default beaver image names. May be overriden in specific stages
         - BEAVER_DOCKER_IMG=builder
         - BEAVER_DOCKER_CONTEXT=docker/builder
@@ -46,20 +47,20 @@ jobs:
     include:
         # Test matrix
         - <<: *test-matrix
-          env: DMD=2.078.* F=production COV=1
+          env: DMD=2.092.* F=production
         - <<: *test-matrix
-          env: DMD=2.078.* F=devel COV=1
+          env: DMD=2.092.* F=devel
         - <<: *test-matrix
-          env: DMD=2.088.* F=production COV=1
+          env: DMD=2.093.* F=production COV=1
         - <<: *test-matrix
-          env: DMD=2.088.* F=devel COV=1
+          env: DMD=2.093.* F=devel COV=1
 
         # Test deployment docker image generation
         - stage: Test
           script:
-              - docker build --build-arg DMD=2.078.* --build-arg DIST=xenial
+              - docker build --build-arg DMD=2.093.* --build-arg DIST=${DIST}
                 -t dlsnode -f docker/Dockerfile.dlsnode .
 
         # Package matrix
         - <<: *package-matrix
-          env: DMD=2.078.* F=production COV=0
+          env: DMD=2.093.* F=production

--- a/Build.mak
+++ b/Build.mak
@@ -4,14 +4,7 @@ ifeq ($(USE_PIC),1)
 	override DFLAGS += -fPIC
 endif
 
-# some D compilers are more picky than others, so tolerating
-# warnings may be necessary in order to build with them
-ifeq ($(ALLOW_WARNINGS), 1)
-	override DFLAGS += -wi
-else
-	override DFLAGS += -w
-endif
-
+override DFLAGS += -w
 override LDFLAGS += -llzo2 -lebtree -lrt -lgcrypt -lgpg-error -lglib-2.0
 
 $B/dlsnode: override LDFLAGS += -lpcre -lebtree
@@ -42,4 +35,3 @@ $O/pkg-dlsnode-common.stamp: \
 $O/pkg-dlsnode.stamp: \
 	$C/pkg/defaults.py \
 	$C/build/$F/bin/dlsnode
-

--- a/Config.mak
+++ b/Config.mak
@@ -1,2 +1,1 @@
 DVER := 2
-PKG_SUFFIX ?= -d$(DVER)

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ Installing
 ----------
 
 DLS node is deployed via Debian packages located on APT server, so the
-installation is as simple as ``sudo apt-get install dlsnode-d1=version``. The
+installation is as simple as ``sudo apt-get install dlsnode=version``. The
 install process doesn't restart already running service, so use ``sudo service
 dls restart`` to restart it.
 
@@ -37,8 +37,7 @@ Processes
 
 A single instance of the DLS node runs on each assigned server.
 DLS' runs in ``/srv/dlsnode`` directory, and upstart script runs
-``/srv/dlsnode/dlsnode`` which should be a symlink normally resolving to
-``/usr/sbin/dlsnode-d1``.
+``/srv/dlsnode/dlsnode`` .
 
 Upstart
 -------

--- a/docker/Dockerfile.dlsnode
+++ b/docker/Dockerfile.dlsnode
@@ -1,7 +1,7 @@
 # Duplicate definition of DIST before FROM is needed to be able to use it
 # in docker image name:
 ARG  DIST=xenial
-FROM sociomantictsunami/develdlang:$DIST-v7 as builder
+FROM sociomantictsunami/develdlang:$DIST-v8 as builder
 # Copies the whole project as makd needs git history:
 COPY . /project/
 WORKDIR /project/
@@ -12,7 +12,7 @@ ENV DMD=$DMD DIST=$DIST
 RUN docker/build.sh
 
 ARG DIST=xenial
-FROM sociomantictsunami/runtimebase:$DIST-v7
+FROM sociomantictsunami/runtimebase:$DIST-v8
 COPY --from=builder /project/build/production/pkg/ /packages/
 COPY docker/install.sh .
 RUN ./install.sh && rm ./install.sh

--- a/docker/builder/beaver.Dockerfile
+++ b/docker/builder/beaver.Dockerfile
@@ -1,1 +1,1 @@
-FROM sociomantictsunami/develdlang:v7
+FROM sociomantictsunami/develdlang:v8

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -8,5 +8,4 @@ apt update
 mkdir -p /srv/dlsnode/etc
 mkdir -p /srv/dlsnode/log
 mkdir -p /srv/dlsnode/data
-apt install -y /packages/dlsnode-d*
-ln -s /usr/sbin/dlsnode-* /usr/sbin/dlsnode
+apt install -y /packages/dlsnode*


### PR DESCRIPTION
```
Since we want to drop support for dmd-transitional,
we need to settle on the minimum supported version of DMD.
Due to the various deprecations and some codeggen bugs in -O -inline,
only v2.092.0 and higher is able to compile our code correctly.

Additionally we now only test on bionic instead of xenial,
and reduced coverage to only the latest version of the compiler.
```